### PR TITLE
Returns *empty* stg if no primes given

### DIFF
--- a/PyBoolNet/StateTransitionGraphs.py
+++ b/PyBoolNet/StateTransitionGraphs.py
@@ -103,6 +103,10 @@ def primes2stg(Primes, Update, InitialStates=lambda x: True):
     
     stg = networkx.DiGraph()
     
+    if len(Primes) == 0:
+        print("No Primes were given. Hence, the stg is empty.") 
+        return stg   
+
     if Update == "asynchronous":
         successors = lambda x: successors_asynchronous(Primes, x)
     if Update == "synchronous":


### PR DESCRIPTION
Hi, 

Here is a pull request to return a stg which is *really* empty if there is no primes. 

Without this modification, `PyBoolNet.StateTransitionGraphs.primes2stg()` returns a stg of 1 node labelled `''` and 1 edge labelled `('', '')`. 


It is quite useful in my case, and it might also help someone else. 

Once again, I hope this change breaks nothing. ;) 

---------------
Details about the behavior: 

```Python
>>> import PyBoolNet
>>> 
>>> bnet = ""
>>> primes = PyBoolNet.FileExchange.bnet2primes(bnet)
>>> 
>>> stg = PyBoolNet.StateTransitionGraphs.primes2stg(
...     primes,
...     "synchronous"
... )
```

|  | Before | After |
| --- | --- | --- |
| `stg.number_of_nodes()` | 1 | 0 |
| `stg.nodes()` | `NodeView(('',))` | `NodeView(())`|
| `stg.number_of_edges()` | 1 | 0 |
| `stg.edges()` | `OutEdgeView([('', '')])` |  `OutEdgeView([])` |


