### PR TITLE
STG with mixed update + other things related to the successor* functions

### DIFF
--- a/PyBoolNet/StateTransitionGraphs.py
+++ b/PyBoolNet/StateTransitionGraphs.py
@@ -715,10 +715,11 @@ def random_successor_mixed(Primes, State):
     names = [x for x in target if target[x] != State[x]]
     k = random.randint(1, len(names))
     
+    successor = State.copy()
     for name in random.sample(names, k):
-        State[name] = target[name]
+        successor[name] = target[name]
     
-    return State
+    return successor
 
 
 def random_state(primes: dict, subspace={}):

--- a/PyBoolNet/StateTransitionGraphs.py
+++ b/PyBoolNet/StateTransitionGraphs.py
@@ -554,10 +554,14 @@ def successor_synchronous(Primes, State):
         * *Successor* (dict): the synchronous successor of *State*
 
     **example**::
-
+            >>> primes = {
+            'v1': [[{'v2': 0}], [{'v2': 1}]],
+            'v2': [[{'v3': 0}, {'v1': 0}], [{'v1': 1, 'v3': 1}]],
+            'v3': [[{'v1': 1, 'v2': 0}], [{'v2': 1}, {'v1': 0}]]
+            }
             >>> state = "100"
             >>> successor_synchronous(primes, state)
-            {'v1':0, 'v2':1, 'v3':1}
+            {'v1': 0, 'v2': 0, 'v3': 0}
     """
     
     if type(State) == str:
@@ -590,10 +594,14 @@ def successors_asynchronous(Primes, State):
         * *Successors* (list): the asynchronous successors of *State*
 
     **example**::
-
-            >>> state = "100"
+            >>> primes = {
+            'v1': [[{'v2': 0}], [{'v2': 1}]],
+            'v2': [[{'v3': 0}, {'v1': 0}], [{'v1': 1, 'v3': 1}]],
+            'v3': [[{'v1': 1, 'v2': 0}], [{'v2': 1}, {'v1': 0}]]
+            }
+            >>> state = "101"
             >>> successors_asynchronous(primes, state)
-            [{'v1':1, 'v2':1, 'v3':1},{'v1':0, 'v2':0, 'v3':1},{'v1':0, 'v2':1, 'v3':0}]
+            [{'v1': 0, 'v2': 0, 'v3': 1}, {'v1': 1, 'v2': 1, 'v3': 1}, {'v1': 1, 'v2': 0, 'v3': 0}]
     """
     
     if type(State) == str:

--- a/PyBoolNet/StateTransitionGraphs.py
+++ b/PyBoolNet/StateTransitionGraphs.py
@@ -636,7 +636,10 @@ def random_successor_mixed(Primes, State):
             >>> random_successor_mixed(primes, state)
             {'v1':1, 'v2':1, 'v3':1}
     """
-    
+
+    if type(State) == str:
+        State = state2dict(Primes, State)
+
     target = successor_synchronous(Primes, State)
     if target == State:
         return target

--- a/PyBoolNet/StateTransitionGraphs.py
+++ b/PyBoolNet/StateTransitionGraphs.py
@@ -646,7 +646,7 @@ def random_successor_mixed(Primes, State):
     
     names = [x for x in target if target[x] != State[x]]
     k = random.randint(1, len(names))
-    successor = State.copy()
+    
     for name in random.sample(names, k):
         State[name] = target[name]
     

--- a/PyBoolNet/Tests/Modules.py
+++ b/PyBoolNet/Tests/Modules.py
@@ -240,6 +240,15 @@ class TestStateTransitionGraphs(unittest.TestCase):
         PyBoolNet.StateTransitionGraphs.random_successor_mixed(primes, state)
         # no assertion
 
+    def test_successors_mixed(self):
+        fname_in = os.path.join(FILES_IN, "randomnet.bnet")
+        fname_out = os.path.join(FILES_OUT, "randomnet.primes")
+        primes = PyBoolNet.FileExchange.bnet2primes(
+            BNET=fname_in, FnamePRIMES=fname_out)
+
+        state = dict([('Gene%i' % (i + 1), i % 2) for i in range(20)])
+        PyBoolNet.StateTransitionGraphs.successors_mixed(primes, state)
+        # no assertion
 
     def test_successors_asynchronous(self):
         fname_in  = os.path.join(FILES_IN,  "randomnet.bnet")


### PR DESCRIPTION
This PR contains the following changes :

- cast string State received in  `random_successor_mixed` as dict. 

I noticed that `random_successor_mixed` does not force cast `State` to dict.
So if State is a string, PyBoolNet throw `TypeError: string indices must be integers`
when running `names = [x for x in target if target[x] != State[x]]`
This potential problem was not caught by the unit test `test_random_mixed_transition` since it is providing a `State` shaped as a dict.

The commit ce72cf6 makes the cast and now allow to run `random_successor_mixed(primes, "010")` (like in the example code that is given in the docstring)

- Remove an unused copy

In `random_successor_mixed`, there was `successor = State.copy()` while the variable `successor` was never used. Commit b01b2ee is deleting this line. 

- Change the example in the doctrings of `successor*_*`

While experimenting a bit with http://page.mi.fu-berlin.de/klarner/iBoolNet/iBoolNet.html, I realised they were no way a BN would produce the transition given in the asynchonous example. 
I modified the examples given in the successor functions (commit 313405d). 
With the example I took, 100 is a fixed point, so I used 101 for the example in `successors_asynchronous`. 


- Finally, the actual purpose of the PR is in commit 8900e9f which allows to compute a state transition graphs with the mixed update scheme.
I tested it on the following example : 
```
bnet = ("""
v1,    v2
v2,    v1 & v3
v3,    !v1 | v2
""")
```
The mixed STG of this bnet contains the following transitions : 
From 010 to :
```
110 (by updating A)
000 (B)
011 (C)
100 (AB)
111 (AC)
001 (BC)
101 (ABC)
```

This example is integrated in the docstring. 


I hope this will be helpful. Do not hesitate if you spot anything wrong. :)