### PR TITLE
Fix type of the lambda successors with mixed update scheme

### DIFF
--- a/PyBoolNet/StateTransitionGraphs.py
+++ b/PyBoolNet/StateTransitionGraphs.py
@@ -113,7 +113,7 @@ def primes2stg(Primes, Update, InitialStates=lambda x: True):
     if Update == "synchronous":
         successors = lambda x: [successor_synchronous(Primes, x)]
     if Update == "mixed":
-        successors = lambda x: [successors_mixed(Primes, x)]
+        successors = lambda x: successors_mixed(Primes, x)
     
     names = sorted(Primes)
     space = len(names) * [[0, 1]]

--- a/PyBoolNet/Tests/Modules.py
+++ b/PyBoolNet/Tests/Modules.py
@@ -299,8 +299,10 @@ class TestStateTransitionGraphs(unittest.TestCase):
 
         PyBoolNet.StateTransitionGraphs.primes2stg(Primes=primes, Update="asynchronous")
         PyBoolNet.StateTransitionGraphs.primes2stg(Primes=primes, Update="synchronous")
+        PyBoolNet.StateTransitionGraphs.primes2stg(Primes=primes, Update="mixed")
         PyBoolNet.StateTransitionGraphs.primes2stg(Primes=primes, Update="asynchronous", InitialStates=init)
         PyBoolNet.StateTransitionGraphs.primes2stg(Primes=primes, Update="synchronous", InitialStates=init)
+        PyBoolNet.StateTransitionGraphs.primes2stg(Primes=primes, Update="mixed", InitialStates=init)
 
         init = []
         stg = PyBoolNet.StateTransitionGraphs.primes2stg(Primes=primes, Update="synchronous", InitialStates=init)


### PR DESCRIPTION
Unfortunately, due to some extra brackets, the type of `successors` computed with the mixed update scheme was a list of list instead of a list of states. The commit also adds a unittest that would have caught this. I should have done this the first time, and I'm really sorry for the inconvenience. :( 

-------
Just a question : 
I realized that running `pytest` does not discover the tests in PyBoolNet/Test/*.py. 
Do you plan to integrate these tests to the CI in the future? 