### PR TITLE
Make all the bnet files from PyBoolNet/Repository openable in R BoolNet.

### DIFF
--- a/PyBoolNet/Repository/n12c5/n12c5.bnet
+++ b/PyBoolNet/Repository/n12c5/n12c5.bnet
@@ -1,4 +1,4 @@
-
+targets, factors
 
 # name: n12c5
 # toy net with monotone edges and five cyclic attractors:

--- a/PyBoolNet/Repository/n3s1c1a/n3s1c1a.bnet
+++ b/PyBoolNet/Repository/n3s1c1a/n3s1c1a.bnet
@@ -1,4 +1,4 @@
-
+targets, factors
 
 # name: n3s1c1a
 # toy net monotone edges and two attractors:

--- a/PyBoolNet/Repository/n3s1c1b/n3s1c1b.bnet
+++ b/PyBoolNet/Repository/n3s1c1b/n3s1c1b.bnet
@@ -1,4 +1,4 @@
-
+targets, factors
 
 # name: n3s1c1b
 # toy net monotone edges and two attractors:

--- a/PyBoolNet/Repository/n5s3/n5s3.bnet
+++ b/PyBoolNet/Repository/n5s3/n5s3.bnet
@@ -1,4 +1,4 @@
-
+targets, factors
 # this is a toy net with three steady states
 
 v1, v2&!v3&!v4&v5 | v2&v3&v4&!v5

--- a/PyBoolNet/Repository/n6s1c2/n6s1c2.bnet
+++ b/PyBoolNet/Repository/n6s1c2/n6s1c2.bnet
@@ -1,4 +1,4 @@
-
+targets, factors
 
 # name: n6s1c2
 # toy net with monotone edges and three attractors:

--- a/PyBoolNet/Repository/n7s3/n7s3.bnet
+++ b/PyBoolNet/Repository/n7s3/n7s3.bnet
@@ -1,4 +1,4 @@
-
+targets, factors
 # toy net with positive edges and three steady states:
 # A1=1111111
 # A2=0000111

--- a/PyBoolNet/Repository/remy_tumorigenesis/remy_tumorigenesis.bnet
+++ b/PyBoolNet/Repository/remy_tumorigenesis/remy_tumorigenesis.bnet
@@ -1,4 +1,4 @@
-
+targets, factors
 #
 # The booleanized model of the multi-valued bladder tumorigenesis model
 # published in the supplementary pdf of 


### PR DESCRIPTION
Hi! 

Of the 25 bnet files I found in `PyBoolNet/Repository`, 18 are openable in R BoolNet, but for the 7 others (mostly toy BNs), the header `targets, factors` is missing. 

This PR is just about adding these headers. :) 

List of the file changed:
- PyBoolNet/Repository/n7s3/n7s3.bnet
- PyBoolNet/Repository/n6s1c2/n6s1c2.bnet
- PyBoolNet/Repository/n12c5/n12c5.bnet
- PyBoolNet/Repository/n3s1c1a/n3s1c1a.bnet
- PyBoolNet/Repository/remy_tumorigenesis/remy_tumorigenesis.bnet
- PyBoolNet/Repository/n3s1c1b/n3s1c1b.bnet
- PyBoolNet/Repository/n5s3/n5s3.bnet


Also, I find the docstring of `FileExancge.primes2bnet()` misleading. What about changing it to

> Saves *Primes* as a *bnet* file, -> optionnaly <-  including the header *"targets, factors"* for compatibility with :ref:`installation_boolnet`.

(Note that the default is without header)