### PR TITLE
unpin matplotlib and networkx versions in dependencies

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -61,8 +61,8 @@ setup(name="PyBoolNet",
           "Topic :: Scientific/Engineering :: Bio-Informatics",
       ],
       install_requires=[
-          "networkx==2.4",
-          "matplotlib==3.3.3",
+          "networkx>=2.4",
+          "matplotlib>=3.3.3",
           "pytest",
           "pyeda==0.28.0"
       ]


### PR DESCRIPTION
RE: https://github.com/hklarner/PyBoolNet/issues/67

did not unpin pyeda, as it was last updated in 2015