### PR TITLE
Python 3.11 compatibility

### DIFF
--- a/pyboolnet/boolean_normal_forms.py
+++ b/pyboolnet/boolean_normal_forms.py
@@ -113,7 +113,7 @@ def functions2mindnf(functions: Dict[str, callable]) -> Dict[str, str]:
 
     expressions = {}
     for name, func in functions.items():
-        inputs = inspect.getargspec(func).args
+        inputs = inspect.getfullargspec(func).args
 
         if not inputs:
             const = func()


### PR DESCRIPTION
Python 3.11 removed the (long) deprecated inspect.getargspec This commit replaces the call with the recommended getfullargspec