### PR TITLE
Update bnet2primes.py: show error message in exception text

### DIFF
--- a/pyboolnet/external/bnet2primes.py
+++ b/pyboolnet/external/bnet2primes.py
@@ -62,7 +62,7 @@ def bnet_file2primes(fname_bnet: str) -> dict:
 
     if not proc.returncode == 0:
         log.error(f"failed to run bnet_file2primes: cmd={' '.join(cmd)}, return_code={proc.returncode}, out={out}")
-        raise Exception
+        raise Exception(err)
 
     out = out.replace("\x08", "")
     out = out.replace(" ", "")


### PR DESCRIPTION
Makes debugging BN files much easier as you can print the exception